### PR TITLE
Add FPE shortcode

### DIFF
--- a/.vscode/markdown.code-snippets
+++ b/.vscode/markdown.code-snippets
@@ -85,17 +85,7 @@
 	"FPE Shortcode": {
 		"prefix": "fpe",
 		"body": [
-			"{{< fpe",
-			"  aid=\"$1\"",
-			"  typ=\"$5\"",
-			"  eq=\"$6\"",
-			"  dep=\"$7\"",
-			"  dest=\"$8\"",
-			"  spd=\"$9\"",
-			"  alt=\"${10}\"",
-			"  rte=\"${11}\"",
-			"  rmk=\"${12}\"",
-			">}}"
+			"{{< fpe aid=\"${1}\" typ=\"${2}\" eq=\"${3}\" dep=\"${4}\" dest=\"${5}\" spd=\"${6}\" alt=\"${7}\" rte=\"${8}\" rmk=\"${9}\" >}}"
 		],
 		"description": "Insert fpe shortcode with editable fields"
 }

--- a/.vscode/markdown.code-snippets
+++ b/.vscode/markdown.code-snippets
@@ -81,5 +81,22 @@
 			"{{< /controller >}}"
 		],
 		"description": "Insert a Hugo controller shortcode with call sign and message"
-	}
+	},
+	"FPE Shortcode": {
+		"prefix": "fpe",
+		"body": [
+			"{{< fpe",
+			"  aid=\"$1\"",
+			"  typ=\"$5\"",
+			"  eq=\"$6\"",
+			"  dep=\"$7\"",
+			"  dest=\"$8\"",
+			"  spd=\"$9\"",
+			"  alt=\"${10}\"",
+			"  rte=\"${11}\"",
+			"  rmk=\"${12}\"",
+			">}}"
+		],
+		"description": "Insert fpe shortcode with editable fields"
+}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,7 @@
     "callsign",
     "Coupeville",
     "coupville",
+    "cruiseid",
     "CYVR",
     "Enroute",
     "Hillsboro",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Run Hugo Server",
       "type": "shell",
-      "command": "hugo server --buildDrafts --disableFastRender --baseURL http://localhost:1313/",
+      "command": "hugo server --noHTTPCache --buildDrafts --disableFastRender --baseURL http://localhost:1313/",
       "problemMatcher": {
         "pattern": {
           "regexp": "^Error:",

--- a/assets/css/fpe.css
+++ b/assets/css/fpe.css
@@ -13,7 +13,7 @@
   margin-top: 8px;
   padding: 4px;
   color: white;
-  font-family: "highgate" sans-serif;
+  font-family: "highgate", sans-serif;
   font-weight: 400;
   font-style:normal;
 }

--- a/assets/css/fpe.css
+++ b/assets/css/fpe.css
@@ -1,0 +1,135 @@
+.fpe-container {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: auto auto auto auto auto;
+  grid-template-areas:
+    "fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title"
+    ". fpe-aid-label   fpe-cid-label   fpe-bcn-label .   fpe-typ-label   fpe-eq-label    fpe-dep-label   fpe-dest-label  fpe-spd-label   fpe-alt-label fpe-amend"
+    ". fpe-aid-box     fpe-cid-box     fpe-bcn-box .    fpe-typ-box     fpe-eq-box     fpe-dep-box     fpe-dest-box    fpe-spd-box     fpe-alt-box  fpe-amend"
+    "fpe-rte-label              fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box"
+    "fpe-rmk-label              fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box";
+  column-gap: 8px;
+  background-color: black;
+  padding: 4px;
+  color: white;
+  font-family: sans-serif;
+}
+
+.fpe-container > div {
+  font-size: 14px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+}
+
+/* Title */
+.fpe-title {
+  grid-area: fpe-title;
+  margin-bottom: 2px;
+  font-size: 12px;
+  color: white;
+}
+
+/* Field Labels */
+.fpe-aid-label,
+.fpe-cid-label,
+.fpe-bcn-label,
+.fpe-typ-label,
+.fpe-eq-label,
+.fpe-dep-label,
+.fpe-dest-label,
+.fpe-spd-label,
+.fpe-alt-label,
+.fpe-rte-label,
+.fpe-rmk-label,
+.fpe-amend {
+  color: white;
+  text-align: center;
+  text-align: center;
+  justify-content: center;
+}
+
+.fpe-amend {
+  color: grey;
+  text-align: center;
+  text-align: center;
+  justify-content: center;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  border: 1px solid #666;
+  padding: 6px 12px; 
+  justify-content: center;
+}
+
+/* Text Fields */
+.fpe-aid-box,
+.fpe-cid-box,
+.fpe-bcn-box,
+.fpe-typ-box,
+.fpe-eq-box,
+.fpe-dep-box,
+.fpe-dest-box,
+.fpe-spd-box,
+.fpe-alt-box,
+.fpe-rte-box,
+.fpe-rmk-box {
+  color: #469be8;
+  background: #111;
+  border: 1px solid #333;
+  padding: 1px 6px 0px 6px;
+  border-radius: 4px;
+  min-height: 24px;
+  text-align: center;
+  justify-content: center;
+  margin-bottom: 4px;
+}
+
+/* Override the borders on three boxes that shouldn't have them. */
+.fpe-aid-box,
+.fpe-cid-box,
+.fpe-bcn-box {
+  border: none;
+}
+
+/* Override the centering on rte and rmk boxes */
+.fpe-rte-box,
+.fpe-rmk-box {
+  text-align: left;
+  justify-content: flex-start;
+  min-height: 40px;
+}
+
+/* Align the rte and rmk labels to the right */
+.fpe-rte-label,
+.fpe-rmk-label {
+  text-align: right;
+  justify-content: flex-end;
+}
+
+/* Individual grid-area assignments */
+.fpe-aid-label    { grid-area: fpe-aid-label; }
+.fpe-cid-label    { grid-area: fpe-cid-label; }
+.fpe-bcn-label    { grid-area: fpe-bcn-label; }
+.fpe-typ-label    { grid-area: fpe-typ-label; }
+.fpe-eq-label     { grid-area: fpe-eq-label; }
+.fpe-dep-label    { grid-area: fpe-dep-label; }
+.fpe-dest-label   { grid-area: fpe-dest-label; }
+.fpe-spd-label    { grid-area: fpe-spd-label; }
+.fpe-alt-label    { grid-area: fpe-alt-label; }
+.fpe-amend       { grid-area: fpe-amend; }
+
+/* Text box areas */
+.fpe-aid-box      { grid-area: fpe-aid-box; }
+.fpe-cid-box      { grid-area: fpe-cid-box; }
+.fpe-bcn-box      { grid-area: fpe-bcn-box; }
+.fpe-typ-box      { grid-area: fpe-typ-box; }
+.fpe-eq-box       { grid-area: fpe-eq-box; }
+.fpe-dep-box      { grid-area: fpe-dep-box; }
+.fpe-dest-box     { grid-area: fpe-dest-box; }
+.fpe-spd-box      { grid-area: fpe-spd-box; }
+.fpe-alt-box      { grid-area: fpe-alt-box; }
+
+.fpe-rte-label     { grid-area: fpe-rte-label; }
+.fpe-rte-box     { grid-area: fpe-rte-box; }
+.fpe-rmk-label     { grid-area: fpe-rmk-label; } 
+.fpe-rmk-box     { grid-area: fpe-rmk-box; }

--- a/assets/css/fpe.css
+++ b/assets/css/fpe.css
@@ -57,9 +57,9 @@
   text-align: center;
   text-align: center;
   justify-content: center;
-  margin-top: 4px;
+  margin-top: 6px;
   margin-bottom: 4px;
-  border: 1px solid #666;
+  border: 2px solid #425595;
   padding: 6px 12px; 
   justify-content: center;
 }

--- a/assets/css/fpe.css
+++ b/assets/css/fpe.css
@@ -1,6 +1,6 @@
 .fpe-container {
   display: grid;
-  grid-template-columns: repeat(12, 1fr);
+  grid-template-columns: 1fr 1fr 1fr 1fr max-content 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
   grid-template-rows: auto auto auto auto auto;
   grid-template-areas:
     "fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title"

--- a/assets/css/fpe.css
+++ b/assets/css/fpe.css
@@ -4,7 +4,7 @@
   grid-template-rows: auto auto auto auto auto;
   grid-template-areas:
     "fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title"
-    ". fpe-aid-label   fpe-cid-label   fpe-bcn-label .   fpe-typ-label   fpe-eq-label    fpe-dep-label   fpe-dest-label  fpe-spd-label   fpe-alt-label fpe-amend"
+    ". fpe-aid-label   fpe-cid-label   fpe-bcn-label fpe-refresh-label   fpe-typ-label   fpe-eq-label    fpe-dep-label   fpe-dest-label  fpe-spd-label   fpe-alt-label fpe-amend"
     ". fpe-aid-box     fpe-cid-box     fpe-bcn-box .    fpe-typ-box     fpe-eq-box     fpe-dep-box     fpe-dest-box    fpe-spd-box     fpe-alt-box  fpe-amend"
     "fpe-rte-label              fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box"
     "fpe-rmk-label              fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box";
@@ -25,6 +25,7 @@
 /* Title */
 .fpe-title {
   grid-area: fpe-title;
+  margin-left: 2px;
   margin-bottom: 2px;
   font-size: 12px;
   color: white;
@@ -110,6 +111,7 @@
 .fpe-aid-label    { grid-area: fpe-aid-label; }
 .fpe-cid-label    { grid-area: fpe-cid-label; }
 .fpe-bcn-label    { grid-area: fpe-bcn-label; }
+.fpe-refresh-label { grid-area: fpe-refresh-label; }
 .fpe-typ-label    { grid-area: fpe-typ-label; }
 .fpe-eq-label     { grid-area: fpe-eq-label; }
 .fpe-dep-label    { grid-area: fpe-dep-label; }

--- a/assets/css/fpe.css
+++ b/assets/css/fpe.css
@@ -12,7 +12,9 @@
   background-color: black;
   padding: 4px;
   color: white;
-  font-family: sans-serif;
+  font-family: "highgate" sans-serif;
+  font-weight: 400;
+  font-style:normal;
 }
 
 .fpe-container > div {

--- a/assets/css/fpe.css
+++ b/assets/css/fpe.css
@@ -3,11 +3,11 @@
   grid-template-columns: 1fr 1fr 1fr 1fr max-content 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
   grid-template-rows: auto auto auto auto auto;
   grid-template-areas:
-    "fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title       fpe-title"
-    ". fpe-aid-label   fpe-cid-label   fpe-bcn-label fpe-refresh-label   fpe-typ-label   fpe-eq-label    fpe-dep-label   fpe-dest-label  fpe-spd-label   fpe-alt-label fpe-amend"
-    ". fpe-aid-box     fpe-cid-box     fpe-bcn-box .    fpe-typ-box     fpe-eq-box     fpe-dep-box     fpe-dest-box    fpe-spd-box     fpe-alt-box  fpe-amend"
-    "fpe-rte-label              fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box  fpe-rte-box"
-    "fpe-rmk-label              fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box fpe-rmk-box";
+    "fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title"
+    ".                fpe-aid-label    fpe-cruiseid-label fpe-bcn-label  fpe-refresh-label fpe-typ-label   fpe-eq-label    fpe-dep-label    fpe-dest-label   fpe-spd-label    fpe-alt-label    fpe-amend"
+    ".                fpe-aid-box      fpe-cruiseid-box fpe-bcn-box      .                fpe-typ-box      fpe-eq-box      fpe-dep-box      fpe-dest-box     fpe-spd-box      fpe-alt-box      fpe-amend"
+    "fpe-rte-label    fpe-rte-box      fpe-rte-box     fpe-rte-box      fpe-rte-box      fpe-rte-box     fpe-rte-box     fpe-rte-box      fpe-rte-box      fpe-rte-box      fpe-rte-box      fpe-rte-box"
+    "fpe-rmk-label    fpe-rmk-box      fpe-rmk-box     fpe-rmk-box      fpe-rmk-box      fpe-rmk-box     fpe-rmk-box     fpe-rmk-box      fpe-rmk-box      fpe-rmk-box      fpe-rmk-box      fpe-rmk-box";
   column-gap: 8px;
   background-color: black;
   padding: 4px;
@@ -35,7 +35,7 @@
 
 /* Field Labels */
 .fpe-aid-label,
-.fpe-cid-label,
+.fpe-cruiseid-label,
 .fpe-bcn-label,
 .fpe-typ-label,
 .fpe-eq-label,
@@ -66,7 +66,7 @@
 
 /* Text Fields */
 .fpe-aid-box,
-.fpe-cid-box,
+.fpe-cruiseid-box,
 .fpe-bcn-box,
 .fpe-typ-box,
 .fpe-eq-box,
@@ -89,7 +89,7 @@
 
 /* Override the borders on three boxes that shouldn't have them. */
 .fpe-aid-box,
-.fpe-cid-box,
+.fpe-cruiseid-box,
 .fpe-bcn-box {
   border: none;
 }
@@ -111,7 +111,7 @@
 
 /* Individual grid-area assignments */
 .fpe-aid-label    { grid-area: fpe-aid-label; }
-.fpe-cid-label    { grid-area: fpe-cid-label; }
+.fpe-cruiseid-label    { grid-area: fpe-cruiseid-label; }
 .fpe-bcn-label    { grid-area: fpe-bcn-label; }
 .fpe-refresh-label { grid-area: fpe-refresh-label; }
 .fpe-typ-label    { grid-area: fpe-typ-label; }
@@ -124,7 +124,7 @@
 
 /* Text box areas */
 .fpe-aid-box      { grid-area: fpe-aid-box; }
-.fpe-cid-box      { grid-area: fpe-cid-box; }
+.fpe-cruiseid-box      { grid-area: fpe-cruiseid-box; }
 .fpe-bcn-box      { grid-area: fpe-bcn-box; }
 .fpe-typ-box      { grid-area: fpe-typ-box; }
 .fpe-eq-box       { grid-area: fpe-eq-box; }

--- a/assets/css/fpe.css
+++ b/assets/css/fpe.css
@@ -3,7 +3,7 @@
   grid-template-columns: 1fr 1fr 1fr 1fr max-content 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
   grid-template-rows: auto auto auto auto auto;
   grid-template-areas:
-    "fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title"
+    "fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-title        fpe-close"
     ".                fpe-aid-label    fpe-cruiseid-label fpe-bcn-label  fpe-refresh-label fpe-typ-label   fpe-eq-label    fpe-dep-label    fpe-dest-label   fpe-spd-label    fpe-alt-label    fpe-amend"
     ".                fpe-aid-box      fpe-cruiseid-box fpe-bcn-box      .                fpe-typ-box      fpe-eq-box      fpe-dep-box      fpe-dest-box     fpe-spd-box      fpe-alt-box      fpe-amend"
     "fpe-rte-label    fpe-rte-box      fpe-rte-box     fpe-rte-box      fpe-rte-box      fpe-rte-box     fpe-rte-box     fpe-rte-box      fpe-rte-box      fpe-rte-box      fpe-rte-box      fpe-rte-box"
@@ -31,6 +31,13 @@
   margin-bottom: 2px;
   font-size: 12px;
   color: white;
+}
+
+/* Close box */
+.fpe-close {
+  grid-area: fpe-close;
+  margin-right: 4px;
+  text-align: right;
 }
 
 /* Field Labels */

--- a/assets/css/fpe.css
+++ b/assets/css/fpe.css
@@ -10,6 +10,7 @@
     "fpe-rmk-label    fpe-rmk-box      fpe-rmk-box     fpe-rmk-box      fpe-rmk-box      fpe-rmk-box     fpe-rmk-box     fpe-rmk-box      fpe-rmk-box      fpe-rmk-box      fpe-rmk-box      fpe-rmk-box";
   column-gap: 8px;
   background-color: black;
+  margin-top: 8px;
   padding: 4px;
   color: white;
   font-family: "highgate" sans-serif;
@@ -20,7 +21,6 @@
 .fpe-container > div {
   font-size: 14px;
   box-sizing: border-box;
-  display: flex;
   align-items: center;
 }
 
@@ -43,8 +43,6 @@
 .fpe-dest-label,
 .fpe-spd-label,
 .fpe-alt-label,
-.fpe-rte-label,
-.fpe-rmk-label,
 .fpe-amend {
   color: white;
   text-align: center;
@@ -98,15 +96,16 @@
 .fpe-rte-box,
 .fpe-rmk-box {
   text-align: left;
-  justify-content: flex-start;
+  align-items: start;
   min-height: 40px;
 }
 
 /* Align the rte and rmk labels to the right */
 .fpe-rte-label,
 .fpe-rmk-label {
+  color: white;
   text-align: right;
-  justify-content: flex-end;
+  align-items: start;
 }
 
 /* Individual grid-area assignments */

--- a/content/developing-s1/m1-welcome-to-zse/cruise-altitude-assignment/index.md
+++ b/content/developing-s1/m1-welcome-to-zse/cruise-altitude-assignment/index.md
@@ -188,9 +188,9 @@ Alternatively, you can coordinate with the en-route controller to see if they ca
 
 ### Example 4
 
-{{< fpe aid="N10GE" typ="C25C" eq="L" dep="KPDX" dest="KSEA" spd="240" alt="180" rte="COUGA KRIEG HAWKZ8" rmk="TCAS" >}}
+The current altimeter is 29.90 and a pilot files the following flight plan. What do you do?
 
-A C25C/L files **FL180** for a flight from KPDX to KSEA. The current altimeter is 29.90. What do you do?
+{{< fpe aid="N10GE" typ="C25C" eq="L" dep="KPDX" dest="KSEA" spd="240" alt="180" rte="COUGA KRIEG HAWKZ8" rmk="TCAS" >}}
 
 {{% details title="Show answer" closed="true" %}}
 

--- a/content/developing-s1/m1-welcome-to-zse/cruise-altitude-assignment/index.md
+++ b/content/developing-s1/m1-welcome-to-zse/cruise-altitude-assignment/index.md
@@ -188,6 +188,8 @@ Alternatively, you can coordinate with the en-route controller to see if they ca
 
 ### Example 4
 
+{{< fpe >}}
+
 A C25C/L files **FL180** for a flight from KPDX to KSEA. The current altimeter is 29.90. What do you do?
 
 {{% details title="Show answer" closed="true" %}}

--- a/content/developing-s1/m1-welcome-to-zse/cruise-altitude-assignment/index.md
+++ b/content/developing-s1/m1-welcome-to-zse/cruise-altitude-assignment/index.md
@@ -188,7 +188,7 @@ Alternatively, you can coordinate with the en-route controller to see if they ca
 
 ### Example 4
 
-{{< fpe >}}
+{{< fpe aid="N10GE" typ="C25C" eq="L" dep="KPDX" dest="KSEA" spd="240" alt="180" rte="COUGA KRIEG HAWKZ8" rmk="TCAS" >}}
 
 A C25C/L files **FL180** for a flight from KPDX to KSEA. The current altimeter is 29.90. What do you do?
 

--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -1,4 +1,5 @@
 <!-- Custom CSS -->
+<link rel="stylesheet" href="https://use.typekit.net/vbh7vdi.css">
 {{- $custom := resources.Get "css/fpe.css" }} {{- if hugo.IsProduction -}} {{-
 $custom = $custom | minify | fingerprint }}
 <link

--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -1,0 +1,11 @@
+<!-- Custom CSS -->
+{{- $custom := resources.Get "css/fpe.css" }} {{- if hugo.IsProduction -}} {{-
+$custom = $custom | minify | fingerprint }}
+<link
+  href="{{ $custom.RelPermalink }}"
+  rel="stylesheet"
+  integrity="{{ $custom.Data.Integrity }}"
+/>
+{{- else }}
+<link href="{{ $custom.RelPermalink }}" rel="stylesheet" />
+{{- end }}

--- a/layouts/shortcodes/fpe.html
+++ b/layouts/shortcodes/fpe.html
@@ -26,7 +26,7 @@
 <div class="fpe-container">
   <!-- Title -->
   <div class="fpe-title">{{ $aid }} - {{ $name }} ({{ $cid }})</div>
-
+  <div class="fpe-close">&times;</div>
   <!-- Labels -->
   <div class="fpe-aid-label">AID</div>
   <div class="fpe-cruiseid-label">CID</div>

--- a/layouts/shortcodes/fpe.html
+++ b/layouts/shortcodes/fpe.html
@@ -1,3 +1,7 @@
+{{- $icon := index site.Data.icons "refresh" -}}
+{{- $attributes := "height=1em"}}
+{{- $icon = replaceRE "<svg" (printf "<svg %s" $attributes) $icon -}}
+
 <div class="fpe-container">
   <!-- Title row -->
   <div class="fpe-title">AMX495 - Henrik EDDK (1891866)</div>
@@ -6,6 +10,11 @@
   <div class="fpe-aid-label">AID</div>
   <div class="fpe-cid-label">CID</div>
   <div class="fpe-bcn-label">BCN</div>
+  <div class="fpe-refresh-label">
+    <span>
+      {{- $icon | safeHTML -}}
+    </span>
+  </div>
   <div class="fpe-typ-label">TYP</div>
   <div class="fpe-eq-label">EQ</div>
   <div class="fpe-dep-label">DEP</div>

--- a/layouts/shortcodes/fpe.html
+++ b/layouts/shortcodes/fpe.html
@@ -1,20 +1,37 @@
+{{/* ICON SETUP */}}
 {{- $icon := index site.Data.icons "refresh" -}}
 {{- $attributes := "height=1em"}}
 {{- $icon = replaceRE "<svg" (printf "<svg %s" $attributes) $icon -}}
 
-<div class="fpe-container">
-  <!-- Title row -->
-  <div class="fpe-title">AMX495 - Henrik EDDK (1891866)</div>
+{{/* VALUES WITH DEFAULTS */}}
+{{- $aid := .Get "aid" | default "" -}}
+{{- $name := .Get "name" -}}
+{{- if not $name }}
+  {{- $names := slice "Alex" "Bailey" "Charlie" "Dakota" "Emery" "Finley" "Grey" "Harper" "Indigo" "Jordan" "Kai" "Logan" "Morgan" "Nova" "Oakley" "Parker" "Quinn" "Riley" "Skyler" "Taylor" -}}
+  {{- $name = index $names (mod now.UnixNano (len $names)) -}}
+{{- end -}}
+{{- $cid := .Get "cid" | default (add 800000 (mod now.UnixNano 1150000)) -}}
+{{- $cruiseid := .Get "cruiseid" | default (add 100 (mod now.UnixNano 900)) -}}
+{{- $bcn := add 1000 (mod now.UnixNano 9000) -}}
 
-  <!-- Field labels (Row 2) -->
+{{- $typ := .Get "typ" | default "" -}}
+{{- $eq := .Get "eq" | default "" -}}
+{{- $dep := .Get "dep" | default "" -}}
+{{- $dest := .Get "dest" | default "" -}}
+{{- $spd := .Get "spd" | default "" -}}
+{{- $alt := .Get "alt" | default "" -}}
+{{- $rte := .Get "rte" | default "" -}}
+{{- $rmk := .Get "rmk" | default "" -}}
+
+<div class="fpe-container">
+  <!-- Title -->
+  <div class="fpe-title">{{ $aid }} - {{ $name }} ({{ $cid }})</div>
+
+  <!-- Labels -->
   <div class="fpe-aid-label">AID</div>
-  <div class="fpe-cid-label">CID</div>
+  <div class="fpe-cruiseid-label">CID</div>
   <div class="fpe-bcn-label">BCN</div>
-  <div class="fpe-refresh-label">
-    <span>
-      {{- $icon | safeHTML -}}
-    </span>
-  </div>
+  <div class="fpe-refresh-label"><span>{{ $icon | safeHTML }}</span></div>
   <div class="fpe-typ-label">TYP</div>
   <div class="fpe-eq-label">EQ</div>
   <div class="fpe-dep-label">DEP</div>
@@ -23,25 +40,21 @@
   <div class="fpe-alt-label">ALT</div>
   <div class="fpe-amend">Amend</div>
 
-  <!-- Field text boxes (Row 3) -->
-  <div class="fpe-aid-box">AMX495</div>
-  <div class="fpe-cid-box">773</div>
-  <div class="fpe-bcn-box">1502</div>
-  <div class="fpe-typ-box">B738</div>
-  <div class="fpe-eq-box">L</div>
-  <div class="fpe-dep-box">KSEA</div>
-  <div class="fpe-dest-box">MMMX</div>
-  <div class="fpe-spd-box">464</div>
-  <div class="fpe-alt-box">350</div>
+  <!-- Values -->
+  <div class="fpe-aid-box">{{ $aid }}</div>
+  <div class="fpe-cruiseid-box">{{ $cruiseid }}</div>
+  <div class="fpe-bcn-box">{{ $bcn }}</div>
+  <div class="fpe-typ-box">{{ $typ }}</div>
+  <div class="fpe-eq-box">{{ $eq }}</div>
+  <div class="fpe-dep-box">{{ $dep }}</div>
+  <div class="fpe-dest-box">{{ $dest }}</div>
+  <div class="fpe-spd-box">{{ $spd }}</div>
+  <div class="fpe-alt-box">{{ $alt }}</div>
 
-  <!-- Route field (Row 4) -->
+  <!-- RTE + RMK -->
   <div class="fpe-rte-label">RTE</div>
-  <div class="fpe-rte-box">
-    SUMMA LTJ IMB Q35 WINEN Q35 CORKR BAVPE J86 RUTER BECON J13 CUU UJ46 TRC
-    UJ47 SLP UT131 DARAN DARAN
-  </div>
+  <div class="fpe-rte-box">{{ $rte }}</div>
 
-  <!-- Remark field (Row 5) -->
   <div class="fpe-rmk-label">RMK</div>
-  <div class="fpe-rmk-box"></div>
+  <div class="fpe-rmk-box">{{ $rmk }}</div>
 </div>

--- a/layouts/shortcodes/fpe.html
+++ b/layouts/shortcodes/fpe.html
@@ -7,10 +7,10 @@
 {{- $aid := .Get "aid" | default "" -}}
 {{- $name := .Get "name" -}}
 {{- if not $name }}
-  {{- $names := slice "Alex" "Bailey" "Charlie" "Dakota" "Emery" "Finley" "Grey" "Harper" "Indigo" "Jordan" "Kai" "Logan" "Morgan" "Nova" "Oakley" "Parker" "Quinn" "Riley" "Skyler" "Taylor" -}}
+  {{- $names := slice "Alex" "Bailey" "Charlie" "Dakota" "Emery" "Finley" "Gray" "Harper" "Indigo" "Jordan" "Joss" "Logan" "Morgan" "Nova" "Oakley" "Parker" "Quinn" "Riley" "Skyler" "Taylor" -}}
   {{- $name = index $names (mod now.UnixNano (len $names)) -}}
 {{- end -}}
-{{- $cid := .Get "cid" | default (add 800000 (mod now.UnixNano 1150000)) -}}
+{{- $cid := .Get "cid" | default (add 1600000 (mod now.UnixNano 300000)) -}}
 {{- $cruiseid := .Get "cruiseid" | default (add 100 (mod now.UnixNano 900)) -}}
 {{- $bcn := add 1000 (mod now.UnixNano 9000) -}}
 
@@ -19,7 +19,7 @@
 {{- $dep := .Get "dep" | default "" -}}
 {{- $dest := .Get "dest" | default "" -}}
 {{- $spd := .Get "spd" | default "" -}}
-{{- $alt := .Get "alt" | default "" -}}
+{{- $alt := .Get "alt" | default "" -}} 
 {{- $rte := .Get "rte" | default "" -}}
 {{- $rmk := .Get "rmk" | default "" -}}
 

--- a/layouts/shortcodes/fpe.html
+++ b/layouts/shortcodes/fpe.html
@@ -1,0 +1,38 @@
+<div class="fpe-container">
+  <!-- Title row -->
+  <div class="fpe-title">AMX495 - Henrik EDDK (1891866)</div>
+
+  <!-- Field labels (Row 2) -->
+  <div class="fpe-aid-label">AID</div>
+  <div class="fpe-cid-label">CID</div>
+  <div class="fpe-bcn-label">BCN</div>
+  <div class="fpe-typ-label">TYP</div>
+  <div class="fpe-eq-label">EQ</div>
+  <div class="fpe-dep-label">DEP</div>
+  <div class="fpe-dest-label">DEST</div>
+  <div class="fpe-spd-label">SPD</div>
+  <div class="fpe-alt-label">ALT</div>
+  <div class="fpe-amend">Amend</div>
+
+  <!-- Field text boxes (Row 3) -->
+  <div class="fpe-aid-box">AMX495</div>
+  <div class="fpe-cid-box">773</div>
+  <div class="fpe-bcn-box">1502</div>
+  <div class="fpe-typ-box">B738</div>
+  <div class="fpe-eq-box">L</div>
+  <div class="fpe-dep-box">KSEA</div>
+  <div class="fpe-dest-box">MMMX</div>
+  <div class="fpe-spd-box">464</div>
+  <div class="fpe-alt-box">350</div>
+
+  <!-- Route field (Row 4) -->
+  <div class="fpe-rte-label">RTE</div>
+  <div class="fpe-rte-box">
+    SUMMA LTJ IMB Q35 WINEN Q35 CORKR BAVPE J86 RUTER BECON J13 CUU UJ46 TRC
+    UJ47 SLP UT131 DARAN DARAN
+  </div>
+
+  <!-- Remark field (Row 5) -->
+  <div class="fpe-rmk-label">RMK</div>
+  <div class="fpe-rmk-box"></div>
+</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a flight plan element (FPE) shortcode for embedding detailed flight plan blocks with editable fields.
	- Added a new CSS stylesheet for visually enhanced, grid-based FPE layouts.
	- Embedded FPE shortcode usage in an example scenario for improved clarity and interactivity.
	- Integrated custom fonts and optimized CSS delivery for production and development environments.
	- Added a snippet to quickly insert the FPE shortcode with editable attributes in markdown files.

- **Chores**
	- Added "cruiseid" to the spell checker dictionary to prevent false spelling errors.
	- Updated development tasks to disable HTTP caching when running the Hugo server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->